### PR TITLE
Compresses links to /sources/:identifier into a single helper method

### DIFF
--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -73,6 +73,7 @@ module RushHour
     end
 
     get '/sources' do
+      @clients = Client.all
       erb :sources
     end
 
@@ -93,36 +94,8 @@ module RushHour
         "<a href='/sources/#{@client.identifier}'>Link to Source Info</a>"
       end
 
-      def jumpstart_link
-        "<a href='/sources/jumpstartlab'>Jumpstart statistics</a>"
-      end
-
-      def google_link
-        "<a href='/sources/google'>Google Statistics</a>"
-      end
-
-      def apple_link
-        "<a href='/sources/apple'>Apple Statistics</a>"
-      end
-
-      def microsoft_link
-        "<a href='/sources/microsoft'>Microsoft Statistics</a>"
-      end
-
-      def palantir_link
-        "<a href='/sources/palantir'>Palantir Statistics</a>"
-      end
-
-      def yahoo_link
-        "<a href='/sources/yahoo'>Yahoo Statistics</a>"
-      end
-
-      def turing_link
-        "<a href='/sources/turing'>Turing Statistics</a>"
-      end
-
-      def facebook_link
-        "<a href='/sources/facebook'>Facebook Statistics</a>"
+      def identifier_link(identifier)
+        "<a href='/sources/#{identifier}'>#{identifier.capitalize} statistics</a>"
       end
     end
   end

--- a/app/controllers/server.rb
+++ b/app/controllers/server.rb
@@ -97,6 +97,11 @@ module RushHour
       def identifier_link(identifier)
         "<a href='/sources/#{identifier}'>#{identifier.capitalize} statistics</a>"
       end
+
+      def relative_path_link(identifier, root, url)
+        path = url.gsub(root, "")
+        "<a href='/sources/#{identifier}/urls/#{path}'>#{url}</a>"
+      end
     end
   end
 end

--- a/app/views/client/show.erb
+++ b/app/views/client/show.erb
@@ -34,13 +34,12 @@
         <td><%= @client.list_all_verbs.join(', ') %></td>
       </tr>
 
-    <tr>
+      <tr>
         <td>List of URLs (most to least) </td>
         <% @client.sorted_urls_by_request_count.each do |url, count| %>
-        <td>
-          <% relative_path = url.gsub(@client.root_url, "") %>
-          <a href='<%= @client.identifier%>/urls<%= relative_path %>'><%= url %></a>: <%= count %>
-        </td>
+          <td>
+            <%= relative_path_link(@client.identifier, @client.root_url, url) %>: <%= count %>
+          </td>
         <% end %>
       </tr>
     </table>

--- a/app/views/sources.erb
+++ b/app/views/sources.erb
@@ -1,14 +1,6 @@
 <div class="jumbotron">
   <h1>Welcome to Rush Hour</h1>
 </div>
-
-<%= jumpstart_link %> <br>
-<%= google_link %> <br>
-<%= apple_link %> <br>
-<%= microsoft_link %> <br>
-<%= palantir_link %> <br>
-<%= yahoo_link %> <br>
-<%= turing_link %> <br>
-<%= facebook_link %> <br>
-
-
+<% @clients.each do |client| %>
+  <%= identifier_link(client.identifier) %> <br>
+<% end %>

--- a/test/features/pages_for_an_identifier_describe_that_application_test.rb
+++ b/test/features/pages_for_an_identifier_describe_that_application_test.rb
@@ -59,9 +59,9 @@ class IdentifierTest < FeatureTest
 
     assert_equal '/sources', current_path
     assert page.has_content?("Welcome")
-    assert page.has_content?("Jumpstart statistics")
+    assert page.has_content?("Jumpstartlab statistics")
 
-    page.click_link("Jumpstart statistics")
+    page.click_link("Jumpstartlab statistics")
 
     assert_equal '/sources/jumpstartlab', current_path
     assert page.has_content?("Analytics for: jumpstartlab")


### PR DESCRIPTION
Since we can't predict who is going to user our service, we should create links to the different pages programatically. 
